### PR TITLE
feat: create vinyl remaining calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+.next/
+*.log
+.env.local
+.env.*
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+pnpm-lock.yaml

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,4 +8,6 @@ html, body, #__next { height: 100%; }
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f5f7;
+  color: #1d1d1f;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,19 @@
-export const metadata = {
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], display: "swap" });
+
+export const metadata: Metadata = {
   title: "Vinyl Remaining",
   description: "Elegant vinyl roll remaining calculator",
 };
 
-import "./globals.css";
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={inter.className}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- add a typed client-side vinyl remaining calculator with Apple-inspired glassmorphism styling, unit and theme controls
- support preset management, roll history with CSV export, and persistent local storage for user data
- introduce Inter typography, polished global colors, and ignore common build artifacts

## Testing
- `npm run lint` *(fails: Next.js attempts to install @types/react/@types/node but registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6772fe0c832ebe97fe9d1c4354af